### PR TITLE
Implement Type composition

### DIFF
--- a/code/ruby/interpreter.rb
+++ b/code/ruby/interpreter.rb
@@ -592,7 +592,7 @@ class Interpreter
 		when '&'
 			# Intersection of Types, aka what they share.
 
-			shared_keys    = operand_scope.data.keys.each do |key|
+			shared_keys    = operand_scope.data.keys.select do |key|
 				curr_scope.has? key
 			end
 			keys_to_delete = curr_scope.data.keys - shared_keys
@@ -602,7 +602,7 @@ class Interpreter
 			end
 
 		when '^'
-			# Symmetric difference of Types, aka what the don't share.
+			# Symmetric difference of Types, aka what they don't share.
 
 			shared_keys = curr_scope.data.keys.select do |key|
 				operand_scope.has? key

--- a/code/ruby/parser.rb
+++ b/code/ruby/parser.rb
@@ -292,11 +292,8 @@ class Parser
 		it.name      = eat
 
 		until curr? '{'
-			if curr?(TYPE_COMPOSITION_OPERATORS, valid_idents)
-				it.expressions << Composition_Expr.new.tap do |expr|
-					expr.operator   = eat(:operator).value
-					expr.identifier = parse_identifier_expr
-				end
+			if curr?(TYPE_COMPOSITION_OPERATORS, ANY_IDENTIFIER)
+				it.expressions << parse_composition_expr
 			end
 		end
 

--- a/code/ruby/shared/constants.rb
+++ b/code/ruby/shared/constants.rb
@@ -41,7 +41,7 @@ RESERVED                   = %w(
 		true false nil
 		skip stop and or return
 	).sort_by &SORT_BY_LENGTH_DESC # todo, I want to add `remove` here as well but not is not the time.
-TYPE_COMPOSITION_OPERATORS = %w(| & - ^)
+TYPE_COMPOSITION_OPERATORS = %w(| & ~ ^) # Union, Intersection, Removal, Symmetric Difference
 ANY_IDENTIFIER             = %i(identifier Identifier IDENTIFIER)
 GSCOPE                     = :global
 SCOPE_OPERATORS            = %w(./ ../ .../).sort_by &SORT_BY_LENGTH_DESC

--- a/code/ruby/shared/constructs.rb
+++ b/code/ruby/shared/constructs.rb
@@ -41,10 +41,6 @@ class Scope
 		return nil unless key
 		@data.delete(key.to_s)
 	end
-
-	def declarations
-		@data.values
-	end
 end
 
 class Global < Scope

--- a/tests/parser_test.rb
+++ b/tests/parser_test.rb
@@ -463,6 +463,19 @@ class Parser_Test < Minitest::Test
 		assert_equal 'Transform', out.first.expressions.first.identifier.value
 	end
 
+	def test_mixed_inline_compositions
+		out = _parse 'Xform | Transform ~ Vec2 & This ^ That {}'
+		assert_kind_of Composition_Expr, out.first.expressions.first
+		assert_equal '|', out.first.expressions[0].operator
+		assert_equal 'Transform', out.first.expressions[0].identifier.value
+		assert_equal '~', out.first.expressions[1].operator
+		assert_equal 'Vec2', out.first.expressions[1].identifier.value
+		assert_equal '&', out.first.expressions[2].operator
+		assert_equal 'This', out.first.expressions[2].identifier.value
+		assert_equal '^', out.first.expressions[3].operator
+		assert_equal 'That', out.first.expressions[3].identifier.value
+	end
+
 	def test_control_flows
 		out = _parse 'if true
 			celebrate()


### PR DESCRIPTION
* Added actual implementation, whereas it was only barely stubbed out before. The operators evaluate sequentially, regardless of declaration location (inline, inbody)
* Replaced "-" composition operator with "~"
* Shortened #interp_identifier error
* Dry'd parser a tiny bit
* Removed one unused method from constructs
* Added test coverage for all composition operators, and a couple extras