### PR TITLE
Move constructs to Air module

### DIFF
--- a/code/ruby/lexer.rb
+++ b/code/ruby/lexer.rb
@@ -1,6 +1,6 @@
-require './code/ruby/shared/constants'
-require './code/ruby/shared/helpers'
-require './code/ruby/shared/lexeme'
+require_relative 'shared/constants'
+require_relative 'shared/helpers'
+require_relative 'shared/lexeme'
 
 class Lexer
 	attr_accessor :i, :col, :line, :input
@@ -204,7 +204,7 @@ class Lexer
 					it.value = eat
 
 				elsif whitespace? curr
-					it.type = :whitespace
+					it.type  = :whitespace
 					it.value = eat
 
 				elsif numeric?

--- a/code/ruby/parser.rb
+++ b/code/ruby/parser.rb
@@ -1,5 +1,5 @@
-require './code/ruby/shared/expressions'
-require './code/ruby/shared/constants'
+require_relative 'shared/expressions'
+require_relative 'shared/constants'
 
 class Parser
 	attr_accessor :i, :input

--- a/code/ruby/shared/air.rb
+++ b/code/ruby/shared/air.rb
@@ -1,0 +1,2 @@
+module Air
+end

--- a/code/ruby/shared/constructs.rb
+++ b/code/ruby/shared/constructs.rb
@@ -1,199 +1,72 @@
-require './code/ruby/shared/helpers.rb'
+require_relative 'air'
 
 module Air
-end
+	class Scope
+		attr_accessor :enclosing_scope
+		attr_reader :name, :data
 
-class Scope
-	attr_accessor :enclosing_scope
-	attr_reader :name, :data
+		def initialize name, data = {}
+			@name = name
+			@data = data
+		end
 
-	def initialize name, data = {}
-		@name = name
-		@data = data
-	end
+		def [] key
+			@data[key&.to_s]
+		end
 
-	def [] key
-		@data[key&.to_s]
-	end
+		def []= key, value
+			@data[key.to_s] = value
+		end
 
-	def []= key, value
-		@data[key.to_s] = value
-	end
+		def is compare
+			@name == compare
+		end
 
-	def is compare
-		@name == compare
-	end
+		def has? identifier
+			@data.key?(identifier.to_s)
+		end
 
-	def has? identifier
-		@data.key?(identifier.to_s)
-	end
+		# Unused, I think
+		def dig * identifiers
+			@data.dig *identifiers
+		end
 
-	# Unused, I think
-	def dig * identifiers
-		@data.dig *identifiers
-	end
+		def data= new_data
+			@data = new_data
+		end
 
-	def data= new_data
-		@data = new_data
-	end
-
-	def delete key
-		return nil unless key
-		@data.delete(key.to_s)
-	end
-end
-
-class Global < Scope
-	def initialize
-		super self.class.name
-	end
-end
-
-class Type < Scope
-	attr_accessor :expressions, :types
-end
-
-class Instance < Type
-	def initialize name
-		super (name || 'Instance')
-	end
-end
-
-class Return < Scope
-	attr_accessor :value
-
-	def initialize value
-		super 'Return'
-		@value = value
-	end
-end
-
-class Air::Array < Instance
-	attr_accessor :values
-
-	def initialize values = []
-		@values = values
-	end
-
-	def [] index
-		values[index]
-	end
-
-	def []= index, value
-		values[index] = value
-	end
-end
-
-class Tuple < Air::Array
-	def initialize values = []
-		@values = values
-	end
-end
-
-class Number < Instance
-	attr_accessor :numerator, :denominator, :type
-
-	def + other
-		numerator + other.numerator
-	end
-
-	def - other
-		numerator - other.numerator
-	end
-
-	def * other
-		numerator * other.numerator
-	end
-
-	def ** other
-		numerator ** other.numerator
-	end
-
-	def / other
-		numerator / other.numerator
-	end
-
-	def % other
-		numerator % other.numerator
-	end
-
-	def >> other
-		numerator >> other.numerator
-	end
-
-	def << other
-		numerator << other.numerator
-	end
-
-	def ^ other
-		numerator ^ other.numerator
-	end
-
-	def & other
-		numerator & other.numerator
-	end
-
-	def | other
-		numerator | other.numerator
-	end
-end
-
-class Func < Scope
-	attr_accessor :expressions
-end
-
-class Nil < Scope # Like Ruby's NilClass, this represents the absence of a value.
-	def self.shared
-		@instance ||= new
-	end
-
-	private_class_method :new # prevent external instantiation
-
-	def initialize
-		super 'nil'
-	end
-end
-
-class Bool < Scope
-	attr_accessor :truthiness
-
-	def !
-		!@truthiness
-	end
-
-	def self.truthy
-		@truthy ||= new(true)
-	end
-
-	def self.falsy
-		@falsy ||= new(false)
-	end
-
-	private_class_method :new # prevent external instantiation
-
-	def initialize truthiness
-		super (!!truthiness).to_s.capitalize # Scope class only needs @name
-		@truthiness = !!truthiness
-	end
-end
-
-class Left_Exclusive_Range < Range
-	def initialize first, last, exclude_end: false
-		super first, last, exclude_end
-	end
-
-	def each
-		skipped = false
-		super do |x|
-			if skipped
-				yield x
-			else
-				skipped = true
-			end
+		def delete key
+			return nil unless key
+			@data.delete(key.to_s)
 		end
 	end
 
-	def include? val
-		val > self.first && (exclude_end? ? val < self.last : val <= self.last)
+	class Global < Scope
+		def initialize
+			super self.class.name
+		end
+	end
+
+	class Type < Scope
+		attr_accessor :expressions, :types
+	end
+
+	class Instance < Type
+		def initialize name
+			super (name || 'Instance')
+		end
+	end
+
+	class Func < Scope
+		attr_accessor :expressions
+	end
+
+	class Return < Scope
+		attr_accessor :value
+
+		def initialize value
+			super 'Return'
+			@value = value
+		end
 	end
 end

--- a/code/ruby/shared/expressions.rb
+++ b/code/ruby/shared/expressions.rb
@@ -1,4 +1,4 @@
-require './code/ruby/shared/constants'
+require_relative 'constants'
 
 class Expression
 	attr_accessor :value, :type

--- a/code/ruby/shared/helpers.rb
+++ b/code/ruby/shared/helpers.rb
@@ -1,8 +1,8 @@
-require './code/ruby/shared/constants'
-require './code/ruby/shared/constructs'
-require './code/ruby/interpreter'
-require './code/ruby/lexer'
-require './code/ruby/parser'
+require_relative 'constants'
+require_relative 'constructs'
+require_relative '../interpreter'
+require_relative '../lexer'
+require_relative '../parser'
 
 def _interp code
 	expressions  = _parse code

--- a/code/ruby/shared/intrinsics.rb
+++ b/code/ruby/shared/intrinsics.rb
@@ -1,0 +1,132 @@
+require_relative 'air'
+require_relative 'constructs'
+
+module Air
+	# Just as a precaution, I want it to be obvious that references of the Array class in this module, so far, are meant for my implementation of Array, not the intrinsic Ruby array.
+	class Air::Array < Instance
+		attr_accessor :values
+
+		def initialize values = []
+			@values = values
+		end
+
+		def [] index
+			values[index]
+		end
+
+		def []= index, value
+			values[index] = value
+		end
+	end
+
+	class Tuple < Air::Array
+		def initialize values = []
+			@values = values
+		end
+	end
+
+	class Number < Instance
+		attr_accessor :numerator, :denominator, :type
+
+		def + other
+			numerator + other.numerator
+		end
+
+		def - other
+			numerator - other.numerator
+		end
+
+		def * other
+			numerator * other.numerator
+		end
+
+		def ** other
+			numerator ** other.numerator
+		end
+
+		def / other
+			numerator / other.numerator
+		end
+
+		def % other
+			numerator % other.numerator
+		end
+
+		def >> other
+			numerator >> other.numerator
+		end
+
+		def << other
+			numerator << other.numerator
+		end
+
+		def ^ other
+			numerator ^ other.numerator
+		end
+
+		def & other
+			numerator & other.numerator
+		end
+
+		def | other
+			numerator | other.numerator
+		end
+	end
+
+	class Nil < Scope # Like Ruby's NilClass, this represents the absence of a value.
+		def self.shared
+			@instance ||= new
+		end
+
+		private_class_method :new # prevent external instantiation
+
+		def initialize
+			super 'nil'
+		end
+	end
+
+	class Bool < Scope
+		attr_accessor :truthiness
+
+		def !
+			!@truthiness
+		end
+
+		def self.truthy
+			@truthy ||= new(true)
+		end
+
+		def self.falsy
+			@falsy ||= new(false)
+		end
+
+		private_class_method :new # prevent external instantiation
+
+		def initialize truthiness
+			super (!!truthiness).to_s.capitalize # Scope class only needs @name
+			@truthiness = !!truthiness
+		end
+	end
+
+	class Left_Exclusive_Range < Range
+		def initialize first, last, exclude_end: false
+			super first, last, exclude_end
+		end
+
+		def each
+			skipped = false
+			super do |x|
+				if skipped
+					yield x
+				else
+					skipped = true
+				end
+			end
+		end
+
+		def include? val
+			val > self.first && (exclude_end? ? val < self.last : val <= self.last)
+		end
+	end
+
+end

--- a/tests/examples_test.rb
+++ b/tests/examples_test.rb
@@ -1,5 +1,6 @@
 require 'minitest/autorun'
 require './code/ruby/shared/helpers'
+require './code/ruby/shared/intrinsics'
 
 class Examples_Test < Minitest::Test
 	def test_fizz_buzz
@@ -32,7 +33,7 @@ class Examples_Test < Minitest::Test
 		}
 
 		(three, five, fifteen)"
-		assert_instance_of Tuple, out
+		assert_instance_of Air::Tuple, out
 		out.values.each do |it|
 			assert_instance_of Air::Array, it
 		end
@@ -117,9 +118,9 @@ class Examples_Test < Minitest::Test
 		(_running?, a, b, s.port, s, s.start!, s.running?)
 		"
 		assert_equal [false, true, false, 4815], out.values[0..3]
-		assert_instance_of Instance, out.values[4]
-		assert_instance_of Func, out.values[5]
-		assert_instance_of Func, out.values[6]
+		assert_instance_of Air::Instance, out.values[4]
+		assert_instance_of Air::Func, out.values[5]
+		assert_instance_of Air::Func, out.values[6]
 	end
 
 	def test_nested_scopes

--- a/tests/interpreter_test.rb
+++ b/tests/interpreter_test.rb
@@ -64,14 +64,14 @@ class Interpreter_Test < Minitest::Test
 
 	def test_anonymous_func_expr
 		out = _interp '{;}'
-		assert_instance_of Func, out
+		assert_instance_of Air::Func, out
 		assert_empty out.expressions
 		assert_nil out.name
 	end
 
 	def test_empty_func_declaration
 		out = _interp 'open {;}'
-		assert_instance_of Func, out
+		assert_instance_of Air::Func, out
 		assert_empty out.expressions
 		assert_equal 'open', out.name
 	end
@@ -119,7 +119,7 @@ class Interpreter_Test < Minitest::Test
 
 	def test_empty_type_declaration
 		out = _interp 'Island {}'
-		assert_instance_of Type, out
+		assert_instance_of Air::Type, out
 		assert_empty out.expressions
 		assert_equal 'Island', out.name
 	end
@@ -132,15 +132,15 @@ class Interpreter_Test < Minitest::Test
 				`do something with the numbers
 			}
 		}'
-		assert_instance_of Type, out
+		assert_instance_of Air::Type, out
 		assert_instance_of NilClass, out[:computer]
-		assert_instance_of Func, out[:enter]
+		assert_instance_of Air::Func, out[:enter]
 	end
 
 	def test_inline_type_composition_declaration
 		out = _interp 'Number {}
 		Integer | Number {}'
-		assert_instance_of Type, out
+		assert_instance_of Air::Type, out
 		assert_equal %w(Integer Number), out.types
 	end
 
@@ -152,7 +152,7 @@ class Interpreter_Test < Minitest::Test
 		Float {
 			| Number
 		}'
-		assert_instance_of Type, out
+		assert_instance_of Air::Type, out
 		assert_equal %w(Float Number Numeric), out.types
 	end
 
@@ -167,7 +167,7 @@ class Interpreter_Test < Minitest::Test
 		assert_instance_of NilClass, out
 
 		out = _interp 'func { assign_to_nil; }'
-		assert_instance_of Func, out
+		assert_instance_of Air::Func, out
 		assert_instance_of Param_Expr, out.expressions.first
 		assert_equal 'assign_to_nil', out.expressions.first.name
 	end
@@ -190,7 +190,7 @@ class Interpreter_Test < Minitest::Test
 		}
 
 		Island.Hatch.Commodore_64'
-		assert_instance_of Type, out
+		assert_instance_of Air::Type, out
 	end
 
 	def test_constants_cannot_be_reassigned
@@ -326,7 +326,7 @@ class Interpreter_Test < Minitest::Test
 
 	def test_create_tuple
 		out = _interp 'x = (1, 2)'
-		assert_kind_of Tuple, out
+		assert_kind_of Air::Tuple, out
 		assert_equal [1, 2], out.values
 	end
 
@@ -409,7 +409,7 @@ class Interpreter_Test < Minitest::Test
 			| Transform
 			~ Rotation
 		}'
-		assert_kind_of Type, out
+		assert_kind_of Air::Type, out
 		assert_kind_of Composition_Expr, out.expressions.first
 		assert_kind_of Composition_Expr, out.expressions.last
 		assert_equal 'Rotation', out.expressions.last.identifier.value
@@ -420,7 +420,7 @@ class Interpreter_Test < Minitest::Test
 		out = _interp '
 		Transform {}, Physics {}
 		Entity | Transform ~ Physics {}'
-		assert_kind_of Type, out
+		assert_kind_of Air::Type, out
 		assert_kind_of Composition_Expr, out.expressions.first
 		assert_kind_of Composition_Expr, out.expressions.last
 		assert_equal 'Physics', out.expressions.last.identifier.value
@@ -459,7 +459,7 @@ class Interpreter_Test < Minitest::Test
 
 	def test_declared_type_init_with_new_keyword
 		out = _interp 'Type {}, Type.new'
-		assert_instance_of Instance, out
+		assert_instance_of Air::Instance, out
 		assert_equal 'Type', out.name
 	end
 
@@ -477,7 +477,7 @@ class Interpreter_Test < Minitest::Test
 
 			new { position; }
 		}, Transform.new'
-		assert_kind_of Instance, out
+		assert_kind_of Air::Instance, out
 		assert_equal 'Transform', out.name
 		assert_kind_of Array, out.expressions
 		assert_equal 6, out.expressions.count
@@ -499,15 +499,15 @@ class Interpreter_Test < Minitest::Test
 		t = Transform.new
 		(t.position, t.position.y)
 		'
-		assert_kind_of Tuple, out
-		assert_kind_of Instance, out.values.first
+		assert_kind_of Air::Tuple, out
+		assert_kind_of Air::Instance, out.values.first
 		assert_equal 2, out.values.last
 	end
 
 	def test_type_declaration_with_parens
 		out = _interp 'Vector2 { x = 0, y = 1 }
 		pos = Vector2()'
-		assert_instance_of Instance, out
+		assert_instance_of Air::Instance, out
 		data = { 'x' => 0, 'y' => 1 }
 		assert_equal data, out.data
 	end
@@ -556,11 +556,11 @@ class Interpreter_Test < Minitest::Test
 
 		out = _interp "#{shared_code}
 		A.B"
-		assert_instance_of Type, out
+		assert_instance_of Air::Type, out
 
 		out = _interp "#{shared_code}
 		A.B.C.new"
-		assert_instance_of Instance, out
+		assert_instance_of Air::Instance, out
 
 		out = _interp "#{shared_code}
 		A.B.C.new.d"
@@ -632,7 +632,7 @@ class Interpreter_Test < Minitest::Test
 	def test_nested_array_access_by_dot_index
 		out = _interp 'things = [4, [8, 15, 16], 23, [42, 108, 418, 3]]
 		(things.1.0, things.3.1)'
-		assert_instance_of Tuple, out
+		assert_instance_of Air::Tuple, out
 		assert_equal 8, out.values.first
 		assert_equal 108, out.values.last
 	end
@@ -657,7 +657,7 @@ class Interpreter_Test < Minitest::Test
 
 	def test_returns
 		out = _interp 'return 1'
-		assert_instance_of Return, out
+		assert_instance_of Air::Return, out
 		assert_equal 1, out.value
 
 		out = _interp '
@@ -669,7 +669,7 @@ class Interpreter_Test < Minitest::Test
 			return "should not get here"
 		}
 		eject()'
-		assert_instance_of Return, out
+		assert_instance_of Air::Return, out
 		assert_equal "true!", out.value
 	end
 
@@ -838,7 +838,7 @@ class Interpreter_Test < Minitest::Test
 		assert_equal "Transform(4,8)", out.values[0]
 		assert_equal "Transform(12,24)", out.values[1]
 
-		assert_instance_of Instance, out.values[2]
+		assert_instance_of Air::Instance, out.values[2]
 		assert_equal 12, out.values[2][:x]
 		assert_equal 24, out.values[2][:y]
 	end
@@ -866,7 +866,7 @@ class Interpreter_Test < Minitest::Test
 
 			Xform(Vec2(23, 42))
 			"
-			assert_instance_of Instance, out
+			assert_instance_of Air::Instance, out
 			assert_equal ['Xform', 'Transform'], out.types
 		end
 	end

--- a/tests/regression_test.rb
+++ b/tests/regression_test.rb
@@ -156,7 +156,7 @@ class Regression_Test < Minitest::Test
 		s2 = b2.to_s()
 		(b1, s1, b2, s2)
 		'
-		assert_instance_of Instance, out.values[0]
+		assert_instance_of Air::Instance, out.values[0]
 		assert_equal "Big-box", out.values[1]
 		assert_equal "Small-box", out.values[3]
 	end


### PR DESCRIPTION
* Factored some constructs out into intrinsics.rb
* Updated most `require`s to use require_relative, except the ones in tests
* Added Air module
* Prefixed all constructs with Air::, even though it's ugly for now. It'll look better once Lexer/Parser/Interpreter are in the namespace as well

I'll migrate the rest of the project later. I just wanted to make sure the things I'll be building going forward, don't conflict with any existing Ruby identifiers.