### PR TITLE
Add support for http route function syntax

### DIFF
--- a/lib/interpreter.rb
+++ b/lib/interpreter.rb
@@ -556,6 +556,21 @@ class Interpreter
 		type
 	end
 
+	def interp_route expr
+		route             = Air::Route.new expr.name&.value
+		route.expressions = expr.expressions
+		route.http_method = expr.http_method
+		route.path        = expr.path
+
+		route.enclosing_scope = stack.last
+
+		if route.name
+			declare route.name, route
+		else
+			route
+		end
+	end
+
 	def interp_func expr
 		func                 = Air::Func.new expr.name&.value
 		func.expressions     = expr.expressions
@@ -722,6 +737,9 @@ class Interpreter
 
 		when Type_Expr
 			interp_type expr
+
+		when Route_Expr
+			interp_route expr
 
 		when Func_Expr
 			interp_func expr

--- a/lib/shared/constants.rb
+++ b/lib/shared/constants.rb
@@ -1,6 +1,6 @@
 SORT_BY_LENGTH_DESC        = ->(str) { -str.size }
 REFERENCE_PREFIX           = '@' # TODO I'm not sold on this yet
-INTRINSIC_PREFIX           = '#'
+DIRECTIVE_PREFIX           = '#'
 INTERPOLATE_CHAR           = '|'
 COMMENT_CHAR               = '`'
 COMMENT_MULTILINE_CHAR     = '```'

--- a/lib/shared/constructs.rb
+++ b/lib/shared/constructs.rb
@@ -66,6 +66,10 @@ module Air
 		attr_accessor :expressions
 	end
 
+	class Route < Func
+		attr_accessor :http_method, :path
+	end
+
 	class Return < Scope
 		attr_accessor :value
 

--- a/lib/shared/expressions.rb
+++ b/lib/shared/expressions.rb
@@ -69,16 +69,16 @@ class Func_Expr < Expression
 	end
 end
 
-# get '/' home {;}
-# put 'whatever/:id' do_something {;}
-# post 'book/:id/publish' do_something {;}
-class Route_Decl < Func_Expr
-	attr_accessor :name, :method, :path
+# #get '/' home {;}
+# #put 'whatever/:id' do_something {;}
+# #post 'book/:id/publish' do_something {;}
+class Route_Expr < Func_Expr
+	attr_accessor :name, :http_method, :path
 
-	def initialize name, method, path
-		@name   = name
-		@path   = path
-		@method = method
+	def initialize http_method, path, name = nil
+		@http_method = http_method
+		@name        = name
+		@path        = path
 	end
 end
 
@@ -137,7 +137,7 @@ class Operator_Expr < Expression
 end
 
 class Identifier_Expr < Expression
-	attr_accessor :kind, :reference, :scope_operator
+	attr_accessor :kind, :reference, :scope_operator, :directive
 end
 
 class Composition_Expr < Expression

--- a/lib/shared/types.rb
+++ b/lib/shared/types.rb
@@ -12,7 +12,7 @@ module Air
 		def [] index
 			values[index]
 		end
- 
+
 		def []= index, value
 			values[index] = value
 		end
@@ -137,10 +137,5 @@ module Air
 			@declarations['port']   = nil
 			@declarations['routes'] = nil
 		end
-	end
-
-	def self.assert condition = false, message = nil
-		message ||= "TODO Assert triggered message"
-		raise message unless condition
 	end
 end

--- a/test/interpreter_test.rb
+++ b/test/interpreter_test.rb
@@ -1013,4 +1013,23 @@ class Interpreter_Test < Minitest::Test
 			_interp "App | Server {}", false
 		end
 	end
+
+	def test_routes
+		# TODO Test edge cases, route/func param mismatch, etc
+		out = _interp '#get "some/thing/:id" { id;
+			do_something()
+		}'
+
+		assert_instance_of Air::Route, out
+		refute out.name
+		assert_equal 'get', out.http_method.value
+		assert_equal 'some/thing/:id', out.path.value
+		assert_equal 2, out.expressions.count
+
+		out = _interp '#put "posts/:id" replace_post { id; }'
+		assert_equal 'replace_post', out.name
+		assert_equal 'put', out.http_method.value
+		assert_equal 'posts/:id', out.path.value
+		assert_equal 1, out.expressions.count
+	end
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -735,4 +735,19 @@ class Parser_Test < Minitest::Test
 	def test_import_syntax
 		out = _parse 'project_root = ~/'
 	end
+
+	def test_directive_identifier
+		out = _parse '#whatever'
+		assert_instance_of Identifier_Expr, out.first
+		assert out.first.directive
+	end
+
+	def test_route_expression
+		out = _parse '#get "something" {;
+			do_something()
+		}'
+		assert_instance_of Route_Expr, out.first
+		assert_equal 'get', out.first.http_method.value
+		assert_equal "something", out.first.path.value
+	end
 end


### PR DESCRIPTION
* Renamed INTRINSIC_PREFIX to DIRECTIVE_PREFIX
* Parsing an identifier prefixed with directive as routes (for now)
* Parsing directive identifier followed by string followed by function as a Route_Expr (< Func_Expr)
* Interpreting Route_Expr as a regular function