### PR TITLE
Syntax updates for server stuff

### DIFF
--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -500,13 +500,14 @@ class Parser
 		end
 
 		if expr.is_a?(Identifier_Expr) && expr.directive
-			# TODO Currently this applies to all directives, it should be specific.
-
-			path              = eat
-			function          = parse_func
-			route             = Route_Expr.new expr, path, function.name
-			route.expressions = function.expressions
-			return route
+			# TODO This is where #assert calls with args should be parsed
+			if HTTP_DIRECTIVES.include?(expr.value) && curr?(:string)
+				path              = eat
+				function          = parse_func
+				route             = Route_Expr.new expr, path, function.name
+				route.expressions = function.expressions
+				return route
+			end
 		end
 
 		scope_prefix = %w(./ ../ .../).find do |it|

--- a/lib/shared/constants.rb
+++ b/lib/shared/constants.rb
@@ -1,6 +1,7 @@
 SORT_BY_LENGTH_DESC        = ->(str) { -str.size }
 REFERENCE_PREFIX           = '@' # TODO I'm not sold on this yet
 DIRECTIVE_PREFIX           = '#'
+HTTP_DIRECTIVES            = %w(get put patch post delete) # TODO See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods
 INTERPOLATE_CHAR           = '|'
 COMMENT_CHAR               = '`'
 COMMENT_MULTILINE_CHAR     = '```'

--- a/lib/shared/constants.rb
+++ b/lib/shared/constants.rb
@@ -1,7 +1,7 @@
 SORT_BY_LENGTH_DESC        = ->(str) { -str.size }
 REFERENCE_PREFIX           = '@' # TODO I'm not sold on this yet
 DIRECTIVE_PREFIX           = '#'
-HTTP_DIRECTIVES            = %w(get put patch post delete) # TODO See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods
+HTTP_DIRECTIVES            = %w(get put patch post delete head options connect trace)
 INTERPOLATE_CHAR           = '|'
 COMMENT_CHAR               = '`'
 COMMENT_MULTILINE_CHAR     = '```'

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -692,22 +692,15 @@ class Parser_Test < Minitest::Test
 		assert_kind_of Identifier_Expr, out.last
 	end
 
-	# def test_infinite_loop_bug
-	# 	skip "Causes infinite looping, I'll worry about it later."
-	# 	out = _parse 'Identifier {;}'
-	# 	assert_kind_of Type_Expr, out.first
-	#
-	# 	out = _parse 'x; , y; , z;'
-	# 	assert_kind_of Postfix_Expr, out.first
-	# 	assert_kind_of Postfix_Expr, out[1]
-	# 	assert_kind_of Postfix_Expr, out.last
-	# end
-	#
-	# def test_operator_overloading
-	# 	skip "While I figure out what type of *_Expr this should produce."
-	# 	out = _parse '+ { other; }'
-	# 	assert_kind_of Func_Expr, out.first
-	# end
+	def test_infinite_loop_bug
+		out = _parse 'Identifier {;}'
+		assert_kind_of Type_Expr, out.first
+
+		out = _parse 'x; , y; , z;'
+		assert_kind_of Postfix_Expr, out.first
+		assert_kind_of Postfix_Expr, out[1]
+		assert_kind_of Postfix_Expr, out.last
+	end
 
 	def test_double_less_than_is_operator
 		out = _parse '<<'


### PR DESCRIPTION
* Separate http directives from generic directives
* HTTP verb directives parse to Route_Exprs
* Other directives still parse to Identifier_Expr with .directive=true
* Added an incomplete HTTP_DIRECTIVES constant
* Updated tests